### PR TITLE
Remove dependency on std in no_std code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ fn display_derive(s: synstructure::Structure) -> quote::Tokens {
             #[allow(unreachable_code)]
             fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 match *self { #display_body }
-                ::std::result::Result::Ok(())
+                ::core::result::Result::Ok(())
             }
         })
     });


### PR DESCRIPTION
There's an accidental reference to the std crate in the no_std part of this library. Replacing it with a reference to core fixes the problem.