### PR TITLE
Allow variant with no #display attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,14 @@ fn display_derive(s: synstructure::Structure) -> quote::Tokens {
 }
 
 fn display_body(s: &synstructure::Structure) -> Option<quote::Tokens> {
-    let mut msgs = s.variants().iter().map(|v| find_display_msg(&v.ast().attrs));
-    if msgs.all(|msg| msg.is_none()) { return None; }
-
     Some(s.each_variant(|v| {
-        let msg = find_display_msg(&v.ast().attrs).expect("All variants must have display attribute.");
+        let msg = match find_display_msg(&v.ast().attrs) {
+            Some(msg) => msg,
+            None => {
+                let variant_name = v.ast().ident.as_ref();
+                return quote!( return write!(f, #variant_name));
+            }
+        };
         if msg.is_empty() {
             panic!("Expected at least one argument to display attribute");
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -53,3 +53,27 @@ fn enum_error() {
     let s = format!("{}", EnumError::UnitVariant);
     assert_eq!(&s[..], "An error has occurred.");
 }
+
+#[derive(Display)]
+enum EnumWithNoAttr {
+    #[display(fmt = "Error: {}", _0)]
+    TupleVariant(usize),
+    UnitVariant,
+}
+
+#[test]
+fn enum_with_no_attr() {
+    let s = format!("{}", EnumWithNoAttr::TupleVariant(4));
+    assert_eq!(&s[..], "Error: 4");
+    let s = format!("{}", EnumWithNoAttr::UnitVariant);
+    assert_eq!(&s[..], "UnitVariant");
+}
+
+#[derive(Display)]
+struct StructWithNoAttr;
+
+#[test]
+fn struct_with_no_attr() {
+    let s = format!("{}", StructWithNoAttr {});
+    assert_eq!(&s[..], "StructWithNoAttr");
+}


### PR DESCRIPTION
And then, use variant name to display.
e.g.
```rust
#[derive(Display)]
struct StructWithNoAttr;
let s = format!("{}", StructWithNoAttr {});
assert_eq!(&s[..], "StructWithNoAttr");

#[derive(Display)]
enum EnumWithNoAttr {
    A,
}
let s = format!("{}", EnumWithNoAttr::A);
assert_eq!(&s[..], "A");
```
